### PR TITLE
test patch to fix sugar-control-panel warning

### DIFF
--- a/bin/sugar-control-panel
+++ b/bin/sugar-control-panel
@@ -15,6 +15,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
+import gi
+gi.require_version('Xkl', '1.0')
+gi.require_version('SugarExt', '1.0')
+gi.require_version('Wnck', '3.0')
+gi.require_version('Gtk', '3.0')
 
 from jarabe import config
 

--- a/src/jarabe/desktop/favoritesview.py
+++ b/src/jarabe/desktop/favoritesview.py
@@ -42,7 +42,6 @@ from jarabe.view.palettes import JournalPalette
 from jarabe.view.palettes import CurrentActivityPalette
 from jarabe.view.palettes import ActivityPalette
 from jarabe.view.buddyicon import BuddyIcon
-from jarabe.view.buddymenu import BuddyMenu
 from jarabe.model.buddy import get_owner_instance
 from jarabe.model import shell
 from jarabe.model import bundleregistry
@@ -677,6 +676,9 @@ class OwnerIcon(BuddyIcon):
                                               __enter_notify_event_cb)
 
     def create_palette(self):
+        # import BuddyMenu here to avoid recursive import
+        # See ticket https://github.com/sugarlabs/sugar/issues/793
+        from jarabe.view.buddymenu import BuddyMenu
         palette = BuddyMenu(get_owner_instance())
 
         settings = Gio.Settings('org.sugarlabs')

--- a/src/jarabe/view/buddyicon.py
+++ b/src/jarabe/view/buddyicon.py
@@ -16,7 +16,6 @@
 from sugar3.graphics import style
 from sugar3.graphics.icon import CanvasIcon
 
-from jarabe.view.buddymenu import BuddyMenu
 from jarabe.util.normalize import normalize_string
 
 
@@ -40,6 +39,9 @@ class BuddyIcon(CanvasIcon):
         self._update_color()
 
     def create_palette(self):
+        # import BuddyMenu here to avoid recursive import
+        # See ticket https://github.com/sugarlabs/sugar/issues/793
+        from jarabe.view.buddymenu import BuddyMenu
         palette = BuddyMenu(self._buddy)
         self.connect_to_palette_pop_events(palette)
         return palette


### PR DESCRIPTION
@quozl, while working on #793,

I could not understand the following how to fix the following:
```shell
~ ▶︎︎ sugar-control-panel -g timezone
/usr/lib/python3/dist-packages/jarabe/model/bundleregistry.py:24: PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '3.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gtk
ERROR:root:Exception while loading extension:
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/jarabe/controlpanel/cmd.py", line 68, in load_modules
    globals(), locals(), ['model'])
  File "/usr/share/sugar/extensions/cpsection/network/model.py", line 19, in <module>
    gi.require_version('NM', '1.0')
  File "/usr/lib/python3/dist-packages/gi/__init__.py", line 102, in require_version
    raise ValueError('Namespace %s not available' % namespace)
ValueError: Namespace NM not available
/usr/share/sugar/extensions/cpsection/keyboard/model.py:19: PyGIWarning: Xkl was imported without specifying a version first. Use gi.require_version('Xkl', '1.0') before import to ensure that the right version gets loaded.
  from gi.repository import Xkl
/usr/lib/python3/dist-packages/jarabe/journal/model.py:33: PyGIWarning: SugarExt was imported without specifying a version first. Use gi.require_version('SugarExt', '1.0') before import to ensure that the right version gets loaded.
  from gi.repository import SugarExt
/usr/lib/python3/dist-packages/jarabe/frame/eventarea.py:19: PyGIWarning: Wnck was imported without specifying a version first. Use gi.require_version('Wnck', '3.0') before import to ensure that the right version gets loaded.
  from gi.repository import Wnck
ERROR:root:Exception while loading extension:
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/jarabe/controlpanel/cmd.py", line 68, in load_modules
    globals(), locals(), ['model'])
  File "/usr/share/sugar/extensions/cpsection/frame/model.py", line 19, in <module>
    frame = get_view()
  File "/usr/lib/python3/dist-packages/jarabe/frame/__init__.py", line 25, in get_view
    _view = Frame()
  File "/usr/lib/python3/dist-packages/jarabe/frame/frame.py", line 79, in __init__
    self._top_panel = self._create_top_panel()
  File "/usr/lib/python3/dist-packages/jarabe/frame/frame.py", line 145, in _create_top_panel
    activities_tray = ActivitiesTray()
  File "/usr/lib/python3/dist-packages/jarabe/frame/activitiestray.py", line 259, in __init__
    self._invites = invites.get_instance()
  File "/usr/lib/python3/dist-packages/jarabe/model/invites.py", line 299, in get_instance
    _instance = Invites()
  File "/usr/lib/python3/dist-packages/jarabe/model/invites.py", line 167, in __init__
    client_handler = telepathyclient.get_instance()
  File "/usr/lib/python3/dist-packages/jarabe/model/telepathyclient.py", line 134, in get_instance
    _instance = TelepathyClient()
  File "/usr/lib/python3/dist-packages/jarabe/model/telepathyclient.py", line 51, in __init__
    dbus.service.Object.__init__(self, bus_name, SUGAR_CLIENT_PATH)
  File "/usr/lib/python3/dist-packages/dbus/service.py", line 485, in __init__
    self.add_to_connection(conn, object_path)
  File "/usr/lib/python3/dist-packages/dbus/service.py", line 576, in add_to_connection
    self._fallback)
RuntimeError: To make asynchronous calls, receive signals or export objects, D-Bus connections must be attached to a main loop by passing mainloop=... to the constructor or calling dbus.set_default_main_loop(...)


(sugar-control-panel:32248): GLib-CRITICAL **: g_hash_table_destroy: assertion 'hash_table != NULL' failed
Error in sys.excepthook:

Original exception was:

(sugar-control-panel:32248): GLib-CRITICAL **: g_hash_table_destroy: assertion 'hash_table != NULL' failed
Error in sys.excepthook:

Original exception was:
```